### PR TITLE
fix: attach peripherals on main thread

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/ComputerCraft.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/ComputerCraft.java
@@ -13,6 +13,7 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -109,12 +110,18 @@ public class ComputerCraft {
 
         @Override
         public void attach(@Nonnull IComputerAccess computer) {
-            TickHandler.attach(this, computer);
+            MinecraftServer server = this.world.getMinecraftServer();
+            if (server != null) {
+                server.addScheduledTask(() -> TickHandler.attach(this, computer));
+            }
         }
 
         @Override
         public void detach(@Nonnull IComputerAccess computer) {
-            TickHandler.detach(this, computer);
+            MinecraftServer server = this.world.getMinecraftServer();
+            if (server != null) {
+                server.addScheduledTask(() -> TickHandler.detach(this, computer));
+            }
         }
 
         @Nonnull


### PR DESCRIPTION
- fix a crash when attaching/detaching cc perihperals
- attach/detach can be called form either the main or the lua thread and can case a concurrent modification crash with the current implementation