### PR TITLE
1.16.5 forge Vec3 fix

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/IRPathingData.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/IRPathingData.java
@@ -1,7 +1,6 @@
 package cam72cam.immersiverailroading.thirdparty.trackapi;
 
 import cam72cam.mod.math.Vec3d;
-import trackapi.lib.PathingData;
 
 public class IRPathingData extends trackapi.lib.PathingData {
     private Vec3d posCache;
@@ -80,7 +79,7 @@ public class IRPathingData extends trackapi.lib.PathingData {
      */
     @Deprecated
     @Override
-    public trackapi.lib.PathingData setPos(net.minecraft.util.math.vector.Vector3d pos) {
+    public trackapi.lib.PathingData setPos(net.minecraft.util.math.Vec3d pos) {
         super.setPos(pos);
         if (this.posCache == null || !this.posCache.internal().equals(pos)) {
             Vec3d newPos = new Vec3d(pos);

--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/IRPathingData.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/IRPathingData.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.thirdparty.trackapi;
 
 import cam72cam.mod.math.Vec3d;
+import net.minecraft.world.phys.Vec3;
 
 public class IRPathingData extends trackapi.lib.PathingData {
     private Vec3d posCache;
@@ -79,7 +80,7 @@ public class IRPathingData extends trackapi.lib.PathingData {
      */
     @Deprecated
     @Override
-    public trackapi.lib.PathingData setPos(net.minecraft.util.math.Vec3d pos) {
+    public trackapi.lib.PathingData setPos(Vec3 pos) {
         super.setPos(pos);
         if (this.posCache == null || !this.posCache.internal().equals(pos)) {
             Vec3d newPos = new Vec3d(pos);

--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/ITrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/ITrack.java
@@ -4,7 +4,6 @@ import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
 import cam72cam.mod.world.World;
 import trackapi.lib.ITrackV2;
-import net.minecraft.world.phys.Vec3;
 import trackapi.lib.Util;
 
 public interface ITrack {
@@ -50,7 +49,7 @@ public interface ITrack {
             }
 
             @Override
-            public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, net.minecraft.util.math.vector.Vector3d vel, double gauge) {
+            public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, net.minecraft.util.math.Vec3d vel, double gauge) {
                 ITrack.this.getNextPosition(IRPathingData.wrap(pos), new Vec3d(vel), gauge);
             }
         };

--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/ITrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/ITrack.java
@@ -6,6 +6,8 @@ import cam72cam.mod.world.World;
 import trackapi.lib.ITrackV2;
 import trackapi.lib.Util;
 
+import net.minecraft.world.phys.Vec3;
+
 public interface ITrack {
     static boolean isRail(World world, Vec3i pos) {
         return get(world, new Vec3d(pos), true) != null;
@@ -49,7 +51,7 @@ public interface ITrack {
             }
 
             @Override
-            public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, net.minecraft.util.math.Vec3d vel, double gauge) {
+            public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, Vec3 vel, double gauge) {
                 ITrack.this.getNextPosition(IRPathingData.wrap(pos), new Vec3d(vel), gauge);
             }
         };

--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/TileEntityTickableTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/TileEntityTickableTrack.java
@@ -3,7 +3,7 @@ package cam72cam.immersiverailroading.thirdparty.trackapi;
 import cam72cam.mod.ModCore;
 import cam72cam.mod.block.tile.TileEntityTickable;
 import cam72cam.mod.resource.Identifier;
-import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.util.math.Vec3d;
 
 public class TileEntityTickableTrack extends TileEntityTickable implements trackapi.lib.ITrackV2 {
     static {
@@ -30,7 +30,7 @@ public class TileEntityTickableTrack extends TileEntityTickable implements track
     }
 
     @Override
-    public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, Vector3d mot, double gauge) {
+    public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, Vec3d mot, double gauge) {
         track().getNextPosition(pos, mot, gauge);
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/TileEntityTickableTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/thirdparty/trackapi/TileEntityTickableTrack.java
@@ -3,7 +3,8 @@ package cam72cam.immersiverailroading.thirdparty.trackapi;
 import cam72cam.mod.ModCore;
 import cam72cam.mod.block.tile.TileEntityTickable;
 import cam72cam.mod.resource.Identifier;
-import net.minecraft.util.math.Vec3d;
+
+import net.minecraft.world.phys.Vec3;
 
 public class TileEntityTickableTrack extends TileEntityTickable implements trackapi.lib.ITrackV2 {
     static {
@@ -30,7 +31,7 @@ public class TileEntityTickableTrack extends TileEntityTickable implements track
     }
 
     @Override
-    public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, Vec3d mot, double gauge) {
+    public <D extends trackapi.lib.PathingData> void getNextPosition(D pos, Vec3 mot, double gauge) {
         track().getNextPosition(pos, mot, gauge);
     }
 }


### PR DESCRIPTION
sorry about last [PR 25](https://github.com/TeamOpenIndustry/ImmersiveRailroadingIntegration/pull/25). If you have problems with Vec3 imports from 1.16.5 official mappins, please merge this PR, otherwise ignore or close it.